### PR TITLE
feat: add mdiSvg option

### DIFF
--- a/packages/vue-cli-plugin-vuetify/generator/tools/fonts.js
+++ b/packages/vue-cli-plugin-vuetify/generator/tools/fonts.js
@@ -2,7 +2,7 @@ const helpers = require('./helpers')
 const fonts = {
   mdi: {
     package: {
-      '@mdi/font': '^3.6.95',
+      '@mdi/font': '*',
     },
     import: '@mdi/font/css/materialdesignicons.css',
     link: '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@latest/css/materialdesignicons.min.css">',

--- a/packages/vue-cli-plugin-vuetify/generator/tools/fonts.js
+++ b/packages/vue-cli-plugin-vuetify/generator/tools/fonts.js
@@ -7,6 +7,11 @@ const fonts = {
     import: '@mdi/font/css/materialdesignicons.css',
     link: '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@latest/css/materialdesignicons.min.css">',
   },
+  mdiSvg: {
+    package: {
+      '@mdi/js': '^4.7.95',
+    },
+  },
   md: {
     package: {
       'material-design-icons-iconfont': '^5.0.1',
@@ -48,7 +53,9 @@ function addDependencies (api, iconFont) {
 
 function addImports (api, iconFont) {
   api.injectImports(api.entryFile, `import '${fonts.roboto.import}'`)
-  api.injectImports(api.entryFile, `import '${fonts[iconFont].import}'`)
+  if (iconFont !== 'mdiSvg') {
+    api.injectImports(api.entryFile, `import '${fonts[iconFont].import}'`)
+  }
 }
 
 function addLinks (api, iconFont) {
@@ -56,7 +63,9 @@ function addLinks (api, iconFont) {
     const lastLink = lines.reverse().findIndex(line => line.match(/^\s*<\/head>/))
 
     lines.splice(lastLink + 1, 0, `    ${fonts['roboto'].link}`)
-    lines.splice(lastLink + 1, 0, `    ${fonts[iconFont].link}`)
+    if (iconFont !== 'mdiSvg') {
+      lines.splice(lastLink + 1, 0, `    ${fonts[iconFont].link}`)
+    }
 
     return lines.reverse()
   })

--- a/packages/vue-cli-plugin-vuetify/generator/tools/fonts.js
+++ b/packages/vue-cli-plugin-vuetify/generator/tools/fonts.js
@@ -9,7 +9,7 @@ const fonts = {
   },
   mdiSvg: {
     package: {
-      '@mdi/js': '^4.7.95',
+      '@mdi/js': '*',
     },
   },
   md: {

--- a/packages/vue-cli-plugin-vuetify/util/iconfonts.js
+++ b/packages/vue-cli-plugin-vuetify/util/iconfonts.js
@@ -1,5 +1,6 @@
 module.exports = [
   { name: 'Material Design Icons', value: 'mdi' },
+  { name: 'Material Design Icons (SVG)', value: 'mdiSvg' },
   { name: 'Material Icons', value: 'md' },
   { name: 'Font Awesome 5', value: 'fa' },
   { name: 'Font Awesome 4', value: 'fa4' }


### PR DESCRIPTION
Add `mdiSvg` to the list of options that can be selected when using the CLI to add Vuetify to a
project.

CAVEAT: I didn't know how to test this, and I'm not familiar at all with the API for Vue CLI plugins. But this is the option I go with more often than not when bootstrapping a project, so it seemed like it should be there.

Happy to fix, if necessary.