### PR TITLE
fix: add missing null-loader dependency

### DIFF
--- a/packages/vue-cli-plugin-vuetify/package.json
+++ b/packages/vue-cli-plugin-vuetify/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/vuetifyjs/vue-cli-plugin-vuetify#readme",
   "dependencies": {
+    "null-loader": "^3.0.0",
     "semver": "^7.1.2",
     "shelljs": "^0.8.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6891,6 +6891,14 @@ npm-run-path@^4.0.0:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
+null-loader@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-3.0.0.tgz#3e2b6c663c5bda8c73a54357d8fa0708dc61b245"
+  integrity sha512-hf5sNLl8xdRho4UPBOOeoIwT3WhjYcMUQm0zj44EhD6UscMAz72o2udpoDFBgykucdEDGIcd6SXbc/G6zssbzw==
+  dependencies:
+    loader-utils "^1.2.3"
+    schema-utils "^1.0.0"
+
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"


### PR DESCRIPTION
Fix issue in https://github.com/vuetifyjs/vue-cli-plugins/issues/101

On the fresh project adding the `vue add vuetify` plugin results in a missing dependency:

```
WEBPACK  Failed to compile with 9 error(s)

Error in ./node_modules/vuetify/lib/components/VImg/VImg.js

  Module not found: 'null-loader' in '/Users/user/temp/vuetify-create-test'
```