### PR TITLE
fix(dependencies): add undeclared dependencies

### DIFF
--- a/packages/cli-plugin-utils/package.json
+++ b/packages/cli-plugin-utils/package.json
@@ -16,5 +16,8 @@
   },
   "bugs": {
     "url": "https://github.com/vuetifyjs/vue-cli-plugins/issues"
+  },
+  "dependencies": {
+    "semver": "^6.3.0"
   }
 }

--- a/packages/cli-plugin-utils/package.json
+++ b/packages/cli-plugin-utils/package.json
@@ -19,5 +19,10 @@
   },
   "dependencies": {
     "semver": "^6.3.0"
+  },
+  "peerDependenciesMeta": {
+    "sass-loader": {
+      "optional": true
+    }
   }
 }

--- a/packages/vue-cli-plugin-vuetify/package.json
+++ b/packages/vue-cli-plugin-vuetify/package.json
@@ -35,5 +35,10 @@
   "devDependencies": {
     "jest": "^24.9.0",
     "vuetify-loader": "^1.2.2"
+  },
+  "peerDependenciesMeta": {
+    "sass-loader": {
+      "optional": true
+    }
   }
 }

--- a/packages/vue-cli-plugin-vuetify/package.json
+++ b/packages/vue-cli-plugin-vuetify/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/vuetifyjs/vue-cli-plugin-vuetify#readme",
   "dependencies": {
+    "semver": "^6.3.0",
     "shelljs": "^0.8.3"
   },
   "devDependencies": {

--- a/packages/vue-cli-plugin-vuetify/package.json
+++ b/packages/vue-cli-plugin-vuetify/package.json
@@ -39,6 +39,9 @@
   "peerDependenciesMeta": {
     "sass-loader": {
       "optional": true
+    },
+    "vuetify-loader": {
+      "optional": true
     }
   }
 }


### PR DESCRIPTION
`vue-cli-plugin-vuetify` [depends](https://github.com/vuetifyjs/vue-cli-plugins/blob/5ad63c05fa03b9696546c3a0abe608e5c7ccb485/packages/vue-cli-plugin-vuetify/util/helpers.js#L2) on `semver`, but doesn't declare it as a dependency, which causes Yarn 2 PnP to throw `Error: A package is trying to access another package without the second one being listed as a dependency of the first one` when used inside a project.

This PR adds `semver` as a dependency to `vue-cli-plugin-vuetify`, as well as to `@vuetify/cli-plugin-utils` (since I've noticed it has [the same issue](https://github.com/vuetifyjs/vue-cli-plugins/blob/5ad63c05fa03b9696546c3a0abe608e5c7ccb485/packages/cli-plugin-utils/index.js#L2)).

This PR preserves the version of semver (`^6.3.0`) that is declared as a `devDependency` in the root `package.json`(I didn't remove it because I'm not sure if it is used anywhere else).