### PR TITLE
feat(storybook): add config-level options

### DIFF
--- a/packages/vue-cli-plugin-vuetify-storybook/generator/template/_storybook/addon-vuetify/decorator.js
+++ b/packages/vue-cli-plugin-vuetify-storybook/generator/template/_storybook/addon-vuetify/decorator.js
@@ -15,7 +15,7 @@ Vue.use(Vuetify)
 export default makeDecorator({
   name: 'withVuetify',
   parameterName: 'vuetify',
-  wrapper: (storyFn, context, { parameters = {} }) => {
+  wrapper: (storyFn, context, { options = {}, parameters = {} }) => {
     // Reduce to one new URL?
     const searchParams = new URL(window.location).searchParams
     const dark = searchParams.get('eyes-variation') === 'dark'


### PR DESCRIPTION
Allow passing config-level options to decorator.
For example if you have own theme options it's convenient to pass it in config like this:
```
addDecorator(withVuetify({
  theme: {
    dark: false,
    themes: {
      light: {
        primary: '#9C27B2',
      },
    },
  },
}));
```