### PR TITLE
feat(preset): Add support for typescript projects

### DIFF
--- a/packages/cli-plugin-utils/index.js
+++ b/packages/cli-plugin-utils/index.js
@@ -64,11 +64,14 @@ function generatePreset (api, preset, onCreateComplete) {
     return
   }
 
-  const file = 'src/plugins/vuetify.js'
+  const file = getPluginFileName(api)
   const plugin = api.resolve(file)
 
   if (!fs.existsSync(plugin)) {
-    console.warn('Unable to locate `vuetify.js` plugin file in `src/plugins`.')
+    const fileSeparatorIndex = file.lastIndexOf('/')
+    const fileName = file.substr(fileSeparatorIndex + 1)
+    const filePath = file.substr(0, fileSeparatorIndex);
+    console.warn(`Unable to locate \`${fileName}\` plugin file in \`${filePath}\`.`)
 
     return
   }
@@ -80,6 +83,12 @@ function generatePreset (api, preset, onCreateComplete) {
 
     typeof onCreateComplete === 'function' && onCreateComplete()
   })
+}
+
+// Returns the path to the vuetify plugin file, adjusting if typescript is added
+function getPluginFileName(api) {
+  const extension = api.hasPlugin('typescript') ? 'ts' : 'js'
+  return `src/plugins/vuetify.${extension}`
 }
 
 // Check if file exists in user project
@@ -119,7 +128,8 @@ function updateFile (api, file, callback) {
 
 // Add new property to the Vuetify object
 function updateVuetifyObject (api, value) {
-  updateFile(api, 'src/plugins/vuetify.js', content => {
+  const pluginFile = getPluginFileName(api)
+  updateFile(api, pluginFile, content => {
     const existingValue = str => (
       str.indexOf(`${value},`) > -1 ||
       str.indexOf(`${value}:`) > -1
@@ -136,7 +146,7 @@ function updateVuetifyObject (api, value) {
     const vuetify = content[index]
 
     if (!vuetify) {
-      console.warn('Unable to locate Vuetify instantiation in `src/plugins/vuetify.js`.')
+      console.warn(`Unable to locate Vuetify instantiation in \`${pluginFile}\`.`)
 
       return
     }
@@ -185,6 +195,7 @@ function VuetifyPresetGenerator (api, preset, onCreateComplete) {
 module.exports = {
   fileExists,
   generatePreset,
+  getPluginFileName,
   injectGoogleFontLink,
   injectHtmlLink,
   injectSassVariables,


### PR DESCRIPTION
Adds the ability to look for the vuetify plugin file in typescript projects.

Following normal app scaffolding procedures, you will install official vue plugins first, like typescript, and then later install vuetify and vuetify presets.

```
$ vue create app-name


Vue CLI v4.3.1
? Generate project in current directory? Yes


Vue CLI v4.3.1
? Please pick a preset: Manually select features
? Check the features needed for your project: Babel, TS, Linter
? Use class-style component syntax? Yes
? Use Babel alongside TypeScript (required for modern mode, auto-detected polyfills, transpiling JSX)? Yes
? Pick a linter / formatter config: Prettier
? Pick additional lint features: (Press <space> to select, <a> to toggle all, <i> to invert selection)Lint on save
? Where do you prefer placing config for Babel, PostCSS, ESLint, etc.? In dedicated config files
? Save this as a preset for future projects? No

$ vue add vuetify

📦  Installing vue-cli-plugin-vuetify...

✔  Successfully installed plugin: vue-cli-plugin-vuetify

? Choose a preset: Configure (advanced)
? Use a pre-made template? (will replace App.vue and HelloWorld.vue) No
? Use custom theme? No
? Use custom properties (CSS variables)? No
? Select icon font Material Design Icons
? Use fonts as a dependency (for Electron or offline)? No
? Use a-la-carte components? Yes
? Select locale English

🚀  Invoking generator for vue-cli-plugin-vuetify...
⚓  Running completion hooks...

✔  Successfully invoked generator for plugin: vue-cli-plugin-vuetify
 vuetify  Discord community: https://community.vuetifyjs.com
 vuetify  Github: https://github.com/vuetifyjs/vuetify
 vuetify  Support Vuetify: https://github.com/sponsors/johnleider

$ ls src/plugins/
vuetify.ts
```

After completion hooks are run, the `src/plugins/vuetify.ts` file is created.

Afterwards, creating a new vuetify preset with a generator that injects itself will fail due to hard coded `.js` file extension for the preset. My workaround right now is to rename the file before and after adding the preset, but this gets interrupted when trying to make a vue preset or any scripting to automate the process of adding vuetify and a vuetify preset to a project.

```
$ vue add vuetify-preset-basil

 📦  Installing vue-cli-plugin-vuetify-preset-basil...

✔  Successfully installed plugin: vue-cli-plugin-vuetify-preset-basil


🚀  Invoking generator for vue-cli-plugin-vuetify-preset-basil...
Unable to locate `vuetify.js` plugin file in `src/plugins`.
⚓  Running completion hooks...

✔  Successfully invoked generator for plugin: vue-cli-plugin-vuetify-preset-basil
```