### PR TITLE
 fix(sass-loader): prependData removed from v9

### DIFF
--- a/packages/vue-cli-plugin-vuetify/util/helpers.js
+++ b/packages/vue-cli-plugin-vuetify/util/helpers.js
@@ -56,10 +56,14 @@ function mergeRules (api, opt, ext) {
     if (opt.data) data.unshift(opt.data)
 
     opt.data = data.join('\n')
-  } else {
+  } else if (sassLoaderVersion < 9) {
     if (opt.prependData) data.unshift(opt.prependData)
 
     opt.prependData = data.join('\n')
+  } else {
+    if (opt.additionalData) data.unshift(opt.additionalData);
+
+    opt.additionalData = data.join('\n');
   }
 
   return opt


### PR DESCRIPTION
Sass-loader v9 has replaced prependData with additionalData, this pr changes prependData to additionalData when sass-loader v9 or higher is detected