### PR TITLE
fix: use require.resolve for loaders

### DIFF
--- a/packages/vue-cli-plugin-vuetify/index.js
+++ b/packages/vue-cli-plugin-vuetify/index.js
@@ -45,11 +45,11 @@ module.exports = (api) => {
     api.chainWebpack(config => {
       const sassRule = config.module.rule('sass')
       sassRule.uses.clear()
-      sassRule.use('null-loader').loader('null-loader')
+      sassRule.use('null-loader').loader(require.resolve('null-loader'))
 
       const scssRule = config.module.rule('scss')
       scssRule.uses.clear()
-      scssRule.use('null-loader').loader('null-loader')
+      scssRule.use('null-loader').loader(require.resolve('null-loader'))
     })
 
     return


### PR DESCRIPTION
**What's the problem this PR addresses?**

`vue-cli-plugin-vuetify` adds webpack loaders using their name instead of location causing it to depend on hoisting, and to not work under Yarn PnP.

**How did you fix it?**

Use `require.resolve` when adding loaders