### PR TITLE
fix(utils): Add support for sass-loader >= 9

### DIFF
--- a/packages/@vuetify/cli-plugin-utils/index.js
+++ b/packages/@vuetify/cli-plugin-utils/index.js
@@ -99,7 +99,8 @@ function mergeSassVariables (opt, file) {
 
   // Merge with user-defined loader data config
   if (sassLoaderVersion < 8) opt.data = variables
-  else opt.prependData = variables
+  else if (sassLoaderVersion < 9) opt.prependData = variables
+  else opt.additionalData = variables
 
   return opt
 }


### PR DESCRIPTION
sass-loader >= 9 introduced a breaking change, removing `prependData` in favor of `additionalData`

https://github.com/webpack-contrib/sass-loader/releases/tag/v9.0.0