### PR TITLE
fix: merge `transformAssetUrls` options

### DIFF
--- a/packages/vue-cli-plugin-vuetify/index.js
+++ b/packages/vue-cli-plugin-vuetify/index.js
@@ -25,19 +25,24 @@ module.exports = (api) => {
     config.module
       .rule('vue')
       .use('vue-loader')
-      .tap(options => ({
-        ...options,
-        transformAssetUrls: {
-          // v-app-bar extends v-toolbar
-          'v-app-bar': 'src',
-          // v-carousel-item extends v-img
-          'v-carousel-item': ['src', 'lazy-src'],
-          'v-img': ['src', 'lazy-src'],
-          'v-navigation-drawer': 'src',
-          'v-parallax': 'src',
-          'v-toolbar': 'src',
-        },
-      }))
+      .tap(options => {
+        const transformAssetUrls = options.transformAssetUrls || {};
+    
+        return ({
+          ...options,
+          transformAssetUrls: {
+            // v-app-bar extends v-toolbar
+            'v-app-bar': 'src',
+            // v-carousel-item extends v-img
+            'v-carousel-item': ['src', 'lazy-src'],
+            'v-img': ['src', 'lazy-src'],
+            'v-navigation-drawer': 'src',
+            'v-parallax': 'src',
+            'v-toolbar': 'src',
+            ...transformAssetUrls
+          },
+        })
+      })
   })
 
   // Avoid loading styles in testing


### PR DESCRIPTION
Hi guys.

I'm using `vuetify` via `vue-cli-plugin-vuetify` at work. 

Yesterday I added `@yzfe/svgicon` plugin for using `*svg` as vue' component and noticed that usage over docs' example doesn't work (see https://mmf-fe.github.io/svgicon/en/guide/#usage). It simply didn't load svg over `<icon data="@icon/arrow.svg" />` method.

```
<template>
    <div>
        <!-- It is assumed that the alias of the svg file path is configured: @icon  -->
        <icon data="@icon/arrow.svg" />
    </div>
</template>
```

`@icon` is configured alias at `.vue-svgicon.config.js` config of `@yzfe/svgicon` plugin.

I tried to install `@yzfe/svgicon` plugin in newly created vue project over `vue create project-name` and it worked. Then I installed `vuetify` over `vue add vuetify` command and icon plugin stoped working.

After some time spent for researching I discovered that yours vue-loader' config doesn't merge `transformAssetUrls`' settings but wiped assigned before setting of others plugins.


