### PR TITLE
fix: use extendPackage to write transpileDependencies

### DIFF
--- a/packages/vue-cli-plugin-vuetify/generator/index.js
+++ b/packages/vue-cli-plugin-vuetify/generator/index.js
@@ -21,6 +21,9 @@ module.exports = (api, opts) => {
 
   if (opts.installFonts) fonts.addDependencies(api, opts.iconFont)
 
+  // Update vue.config.js for transpileDependency if AlaCarte
+  if (opts.useAlaCarte) alaCarte.addVueConfigTranspileDependency(api)
+
   // Update templates
   vuetify.renderFiles(api, { opts })
 
@@ -32,9 +35,6 @@ module.exports = (api, opts) => {
     }
     if (!opts.installFonts) fonts.addLinks(api, opts.iconFont)
     vuetify.setHtmlLang(api, opts.locale)
-
-    // Update vue.config.js for transpileDependency if AlaCarte
-    if (opts.useAlaCarte) vuetify.updateOrCreateVueConfig(api)
 
     api.exitLog('Discord community: https://community.vuetifyjs.com')
     api.exitLog('Github: https://github.com/vuetifyjs/vuetify')

--- a/packages/vue-cli-plugin-vuetify/generator/tools/alaCarte.js
+++ b/packages/vue-cli-plugin-vuetify/generator/tools/alaCarte.js
@@ -8,6 +8,17 @@ function addDependencies (api) {
   })
 }
 
+function addVueConfigTranspileDependency (api) {
+  api.extendPackage({
+    vue: {
+      transpileDependencies: [
+        'vuetify',
+      ],
+    },
+  })
+}
+
 module.exports = {
   addDependencies,
+  addVueConfigTranspileDependency,
 }

--- a/packages/vue-cli-plugin-vuetify/generator/tools/vuetify.js
+++ b/packages/vue-cli-plugin-vuetify/generator/tools/vuetify.js
@@ -64,30 +64,9 @@ function setHtmlLang (api, locale) {
   })
 }
 
-function updateOrCreateVueConfig (api) {
-  const config = api.resolve('vue.config.js')
-
-  if (!fs.existsSync(config)) {
-    fs.writeFileSync(config, 'module.exports = {}', 'utf8')
-  }
-
-  const file = require(config)
-
-  if (!file.transpileDependencies) {
-    file.transpileDependencies = []
-  }
-
-  if (!file.transpileDependencies.includes('vuetify')) {
-    file.transpileDependencies.push('vuetify')
-  }
-
-  fs.writeFileSync(config, `module.exports = ${JSON.stringify(file, 2, 2)}`, 'utf8')
-}
-
 module.exports = {
   addDependencies,
   addImports,
   renderFiles,
   setHtmlLang,
-  updateOrCreateVueConfig,
 }


### PR DESCRIPTION
This will ensure that javascript settings are not lost in `vue.congih.js`, as the current method writes the same using a` JSON.stringify`.

In this way, configurations made previously of adding vuetify via plugin or even presets, do not lose configurations that use javascript.