### PR TITLE
fix(preset-rally): sass-loader incompatibility.

### DIFF
--- a/packages/@vuetify/material-studies/templates/vue-cli-plugin-vuetify-preset-rally/package.json
+++ b/packages/@vuetify/material-studies/templates/vue-cli-plugin-vuetify-preset-rally/package.json
@@ -17,6 +17,6 @@
     "url": "https://github.com/vuetifyjs/vue-cli-plugin-vuetify/issues"
   },
   "dependencies": {
-    "@vuetify/cli-plugin-utils": "^0.0.7"
+    "@vuetify/cli-plugin-utils": "^0.0.9"
   }
 }


### PR DESCRIPTION
I think this fixes #241 for the rally plugin.