### PR TITLE
Removed deprecated null-loader dependency

### DIFF
--- a/packages/vue-cli-plugin-vuetify/index.js
+++ b/packages/vue-cli-plugin-vuetify/index.js
@@ -50,11 +50,11 @@ module.exports = (api) => {
     api.chainWebpack(config => {
       const sassRule = config.module.rule('sass')
       sassRule.uses.clear()
-      sassRule.use('null-loader').loader(require.resolve('null-loader'))
+      config.resolve.alias.set('sass', false)
 
       const scssRule = config.module.rule('scss')
       scssRule.uses.clear()
-      scssRule.use('null-loader').loader(require.resolve('null-loader'))
+      config.resolve.alias.set('scss', false)
     })
 
     return

--- a/packages/vue-cli-plugin-vuetify/package.json
+++ b/packages/vue-cli-plugin-vuetify/package.json
@@ -29,7 +29,6 @@
   },
   "homepage": "https://github.com/vuetifyjs/vue-cli-plugin-vuetify#readme",
   "dependencies": {
-    "null-loader": "^3.0.0",
     "semver": "^7.1.2",
     "shelljs": "^0.8.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6451,14 +6451,6 @@ npm-run-path@^4.0.0:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
-null-loader@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-3.0.0.tgz#3e2b6c663c5bda8c73a54357d8fa0708dc61b245"
-  integrity sha512-hf5sNLl8xdRho4UPBOOeoIwT3WhjYcMUQm0zj44EhD6UscMAz72o2udpoDFBgykucdEDGIcd6SXbc/G6zssbzw==
-  dependencies:
-    loader-utils "^1.2.3"
-    schema-utils "^1.0.0"
-
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"


### PR DESCRIPTION
Note: absolutely not tested, not familiar with chain-webpack, etc.

This should fix: https://github.com/vuetifyjs/vue-cli-plugins/issues/254

Relevant: https://github.com/vuetifyjs/vue-cli-plugins/pull/152

The chain webpack types don't seem to thing that an alias can be false, it appears that they are not up to date with webpack on this: https://webpack.js.org/configuration/resolve/#resolvealias

I thought I'd give it a try, but this is a bit out of my league


