### PR TITLE
fix(material-studies): sass div

### DIFF
--- a/packages/@vuetify/material-studies/templates/vue-cli-plugin-vuetify-preset-basil/preset/variables.scss
+++ b/packages/@vuetify/material-studies/templates/vue-cli-plugin-vuetify-preset-basil/preset/variables.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 @import '~vuetify/src/styles/styles.sass';
 
 // Basil specific variables
@@ -14,7 +16,7 @@ $basil-tabs-tab-width: 100%;
 $body-font-family: 'Montserrat', sans-serif;
 $border-radius-root: 0;
 $btn-font-weight: 700;
-$btn-icon-font-size: #{14 / $basil-font-size}rem;
+$btn-icon-font-size: math.div(14, $basil-font-size)rem;
 $btn-outline-border-width: 2px;
 $dialog-elevation: 0;
 $heading-font-family: 'Lekton', sans-serif;
@@ -22,73 +24,73 @@ $headings: (
   'h1':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{96 / $basil-font-size}rem,
+    'size': math.div(96, $basil-font-size)rem,
     'weight': 600
   ),
   'h2':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{60 / $basil-font-size}rem,
+    'size': math.div(60, $basil-font-size)rem,
     'weight': 600
   ),
   'h3':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{48 / $basil-font-size}rem,
+    'size': math.div(48, $basil-font-size)rem,
     'weight': 600
   ),
   'h4':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{34 / $basil-font-size}rem,
+    'size': math.div(34, $basil-font-size)rem,
     'weight': 600
   ),
   'h5':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{24 / $basil-font-size}rem,
+    'size': math.div(24, $basil-font-size)rem,
     'weight': 500
   ),
   'h6':(
     'font-family': $heading-font-family,
     'letter-spacing': initial,
-    'size': #{21 / $basil-font-size}rem,
+    'size': math.div(21, $basil-font-size)rem,
     'weight': 700
   ),
   'subtitle-1':(
     'font-family': $heading-font-family,
     'letter-spacing': initial,
-    'size': #{17 / $basil-font-size}rem,
+    'size': math.div(17, $basil-font-size)rem,
     'weight': 700
   ),
   'subtitle-2':(
     'font-family': $heading-font-family,
     'letter-spacing': initial,
-    'size': #{15 / $basil-font-size}rem,
+    'size': math.div(15, $basil-font-size)rem,
     'weight': 700
   ),
   'body-1':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{16 / $basil-font-size}rem,
+    'size': math.div(16, $basil-font-size)rem,
     'weight': 600
   ),
   'body-2':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{14 / $basil-font-size}rem,
+    'size': math.div(14, $basil-font-size)rem,
     'weight': 400
   ),
   'caption':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{12 / $basil-font-size}rem,
+    'size': math.div(12, $basil-font-size)rem,
     'weight': 500
   ),
   'overline':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{10 / $basil-font-size}rem,
+    'size': math.div(10, $basil-font-size)rem,
     'weight': 400
   )
 );

--- a/packages/@vuetify/material-studies/templates/vue-cli-plugin-vuetify-preset-fortnightly/preset/variables.scss
+++ b/packages/@vuetify/material-studies/templates/vue-cli-plugin-vuetify-preset-fortnightly/preset/variables.scss
@@ -12,73 +12,73 @@ $headings: (
   'h1':(
     'font-family': $heading-font-family,
     'letter-spacing': initial,
-    'size': #{96 / $fortnightly-font-size}rem,
+    'size': math.div(96, $fortnightly-font-size)rem,
     'weight': 900
   ),
   'h2':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{60 / $fortnightly-font-size}rem,
+    'size': math.div(60, $fortnightly-font-size)rem,
     'weight': 300
   ),
   'h3':(
     'font-family': $heading-font-family,
     'letter-spacing': initial,
-    'size': #{48 / $fortnightly-font-size}rem,
+    'size': math.div(48, $fortnightly-font-size)rem,
     'weight': 900
   ),
   'h4':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{34 / $fortnightly-font-size}rem,
+    'size': math.div(34, $fortnightly-font-size)rem,
     'weight': 400
   ),
   'h5':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{24 / $fortnightly-font-size}rem,
+    'size': math.div(24, $fortnightly-font-size)rem,
     'weight': 400
   ),
   'h6':(
     'font-family': $heading-font-family,
     'letter-spacing': initial,
-    'size': #{20 / $fortnightly-font-size}rem,
+    'size': math.div(20, $fortnightly-font-size)rem,
     'weight': 700
   ),
   'subtitle-1':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{16 / $fortnightly-font-size}rem,
+    'size': math.div(16, $fortnightly-font-size)rem,
     'weight': 500
   ),
   'subtitle-2':(
     'font-family': $heading-font-family,
     'letter-spacing': initial,
-    'size': #{14 / $fortnightly-font-size}rem,
+    'size': math.div(14, $fortnightly-font-size)rem,
     'weight': 500
   ),
   'body-1':(
     'font-family': $heading-font-family,
     'letter-spacing': initial,
-    'size': #{16 / $fortnightly-font-size}rem,
+    'size': math.div(16, $fortnightly-font-size)rem,
     'weight': 400
   ),
   'body-2':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{14 / $fortnightly-font-size}rem,
+    'size': math.div(14, $fortnightly-font-size)rem,
     'weight': 400
   ),
   'caption':(
     'font-family': $heading-font-family,
     'letter-spacing': initial,
-    'size': #{12 / $fortnightly-font-size}rem,
+    'size': math.div(12, $fortnightly-font-size)rem,
     'weight': 400
   ),
   'overline':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{10 / $fortnightly-font-size}rem,
+    'size': math.div(10, $fortnightly-font-size)rem,
     'weight': 700
   )
 );

--- a/packages/@vuetify/material-studies/templates/vue-cli-plugin-vuetify-preset-owl/preset/variables.scss
+++ b/packages/@vuetify/material-studies/templates/vue-cli-plugin-vuetify-preset-owl/preset/variables.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 @import '~vuetify/src/styles/styles.sass';
 
 // Owl specific variables
@@ -20,73 +22,73 @@ $headings: (
   'h1':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{96 / $owl-font-size}rem,
+    'size': math.div(96, $owl-font-size)rem,
     'weight': 700
   ),
   'h2':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{60 / $owl-font-size}rem,
+    'size': math.div(60, $owl-font-size)rem,
     'weight': 700
   ),
   'h3':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{48 / $owl-font-size}rem,
+    'size': math.div(48, $owl-font-size)rem,
     'weight': 700
   ),
   'h4':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{34 / $owl-font-size}rem,
+    'size': math.div(34, $owl-font-size)rem,
     'weight': 700
   ),
   'h5':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{24 / $owl-font-size}rem,
+    'size': math.div(24, $owl-font-size)rem,
     'weight': 700
   ),
   'h6':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{20 / $owl-font-size}rem,
+    'size': math.div(20, $owl-font-size)rem,
     'weight': 500
   ),
   'subtitle-1':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{16 / $owl-font-size}rem,
+    'size': math.div(16, $owl-font-size)rem,
     'weight': 500
   ),
   'subtitle-2':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{14 / $owl-font-size}rem,
+    'size': math.div(14, $owl-font-size)rem,
     'weight': 400
   ),
   'body-1':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{16 / $owl-font-size}rem,
+    'size': math.div(16, $owl-font-size)rem,
     'weight': 400
   ),
   'body-2':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{14 / $owl-font-size}rem,
+    'size': math.div(14, $owl-font-size)rem,
     'weight': 400
   ),
   'caption':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{12 / $owl-font-size}rem,
+    'size': math.div(12, $owl-font-size)rem,
     'weight': 400
   ),
   'overline':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{10 / $owl-font-size}rem,
+    'size': math.div(10, $owl-font-size)rem,
     'weight': 400
   )
 );

--- a/packages/@vuetify/material-studies/templates/vue-cli-plugin-vuetify-preset-rally/preset/variables.scss
+++ b/packages/@vuetify/material-studies/templates/vue-cli-plugin-vuetify-preset-rally/preset/variables.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 @import '~vuetify/src/styles/styles.sass';
 
 // Rally specific variables
@@ -11,7 +13,7 @@ $rally-text-color: #FFFFFF;
 $body-font-family: 'Roboto Condensed', sans-serif;
 $heading-font-family: 'Eczar', sans-serif;
 $border-radius-root: 0;
-$btn-font-size: #{14 / $rally-font-size}rem;
+$btn-font-size: math.div(14, $rally-font-size)rem;
 $btn-font-weight: 700;
 $card-box-shadow: none;
 $dialog-card-subtitle-padding: 24px;
@@ -22,73 +24,73 @@ $headings: (
   'h1':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{96 / $rally-font-size}rem,
+    'size': math.div(96, $rally-font-size)rem,
     'weight': 300
   ),
   'h2':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{60 / $rally-font-size}rem,
+    'size': math.div(60, $rally-font-size)rem,
     'weight': 300
   ),
   'h3':(
     'font-family': $heading-font-family,
     'letter-spacing': initial,
-    'size': #{48 / $rally-font-size}rem,
+    'size': math.div(48, $rally-font-size)rem,
     'weight': 400
   ),
   'h4':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{34 / $rally-font-size}rem,
+    'size': math.div(34, $rally-font-size)rem,
     'weight': 400
   ),
   'h5':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{24 / $rally-font-size}rem,
+    'size': math.div(24, $rally-font-size)rem,
     'weight': 400
   ),
   'h6':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{20 / $rally-font-size}rem,
+    'size': math.div(20, $rally-font-size)rem,
     'weight': 500
   ),
   'subtitle-1':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{16 / $rally-font-size}rem,
+    'size': math.div(16, $rally-font-size)rem,
     'weight': 400
   ),
   'subtitle-2':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{14 / $rally-font-size}rem,
+    'size': math.div(14, $rally-font-size)rem,
     'weight': 500
   ),
   'body-1':(
     'font-family': $heading-font-family,
     'letter-spacing': initial,
-    'size': #{16 / $rally-font-size}rem,
+    'size': math.div(16, $rally-font-size)rem,
     'weight': 400
   ),
   'body-2':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{14 / $rally-font-size}rem,
+    'size': math.div(14, $rally-font-size)rem,
     'weight': 300
   ),
   'caption':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{12 / $rally-font-size}rem,
+    'size': math.div(12, $rally-font-size)rem,
     'weight': 400
   ),
   'overline':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{10 / $rally-font-size}rem,
+    'size': math.div(10, $rally-font-size)rem,
     'weight': 400
   )
 );

--- a/packages/@vuetify/material-studies/templates/vue-cli-plugin-vuetify-preset-reply/preset/variables.scss
+++ b/packages/@vuetify/material-studies/templates/vue-cli-plugin-vuetify-preset-reply/preset/variables.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 @import '~vuetify/src/styles/styles.sass';
 
 // Reply specific variables
@@ -13,73 +15,73 @@ $headings: (
   'h1':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{96 / $reply-font-size}rem,
+    'size': math.div(96, $reply-font-size)rem,
     'weight': 300
   ),
   'h2':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{60 / $reply-font-size}rem,
+    'size': math.div(60, $reply-font-size)rem,
     'weight': 600
   ),
   'h3':(
     'font-family': $heading-font-family,
     'letter-spacing': initial,
-    'size': #{48 / $reply-font-size}rem,
+    'size': math.div(48, $reply-font-size)rem,
     'weight': 400
   ),
   'h4':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{34 / $reply-font-size}rem,
+    'size': math.div(34, $reply-font-size)rem,
     'weight': 400
   ),
   'h5':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{24 / $reply-font-size}rem,
+    'size': math.div(24, $reply-font-size)rem,
     'weight': 700
   ),
   'h6':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{20 / $reply-font-size}rem,
+    'size': math.div(20, $reply-font-size)rem,
     'weight': 500
   ),
   'subtitle-1':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{16 / $reply-font-size}rem,
+    'size': math.div(16, $reply-font-size)rem,
     'weight': 400
   ),
   'subtitle-2':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{14 / $reply-font-size}rem,
+    'size': math.div(14, $reply-font-size)rem,
     'weight': 500
   ),
   'body-1':(
     'font-family': $heading-font-family,
     'letter-spacing': initial,
-    'size': #{18 / $reply-font-size}rem,
+    'size': math.div(18, $reply-font-size)rem,
     'weight': 400
   ),
   'body-2':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{14 / $reply-font-size}rem,
+    'size': math.div(14, $reply-font-size)rem,
     'weight': 400
   ),
   'caption':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{12 / $reply-font-size}rem,
+    'size': math.div(12, $reply-font-size)rem,
     'weight': 400
   ),
   'overline':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{12 / $reply-font-size}rem,
+    'size': math.div(12, $reply-font-size)rem,
     'weight': 600
   )
 );

--- a/packages/@vuetify/material-studies/templates/vue-cli-plugin-vuetify-preset-shrine/preset/variables.scss
+++ b/packages/@vuetify/material-studies/templates/vue-cli-plugin-vuetify-preset-shrine/preset/variables.scss
@@ -1,3 +1,6 @@
+
+@use 'sass:math';
+
 @import '~vuetify/src/styles/styles.sass';
 
 // Shrine specific variables
@@ -22,73 +25,73 @@ $headings: (
   'h1':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{96 / $shrine-font-size}rem,
+    'size': math.div(96, $shrine-font-size)rem,
     'weight': 300
   ),
   'h2':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{60 / $shrine-font-size}rem,
+    'size': math.div(60, $shrine-font-size)rem,
     'weight': 300
   ),
   'h3':(
     'font-family': $heading-font-family,
     'letter-spacing': initial,
-    'size': #{48 / $shrine-font-size}rem,
+    'size': math.div(48, $shrine-font-size)rem,
     'weight': 400
   ),
   'h4':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{34 / $shrine-font-size}rem,
+    'size': math.div(34, $shrine-font-size)rem,
     'weight': 400
   ),
   'h5':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{24 / $shrine-font-size}rem,
+    'size': math.div(24, $shrine-font-size)rem,
     'weight': 500
   ),
   'h6':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{20 / $shrine-font-size}rem,
+    'size': math.div(20, $shrine-font-size)rem,
     'weight': 500
   ),
   'subtitle-1':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{16 / $shrine-font-size}rem,
+    'size': math.div(16, $shrine-font-size)rem,
     'weight': 500
   ),
   'subtitle-2':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{14 / $shrine-font-size}rem,
+    'size': math.div(14, $shrine-font-size)rem,
     'weight': 500
   ),
   'body-1':(
     'font-family': $heading-font-family,
     'letter-spacing': initial,
-    'size': #{16 / $shrine-font-size}rem,
+    'size': math.div(16, $shrine-font-size)rem,
     'weight': 400
   ),
   'body-2':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{14 / $shrine-font-size}rem,
+    'size': math.div(14, $shrine-font-size)rem,
     'weight': 400
   ),
   'caption':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{12 / $shrine-font-size}rem,
+    'size': math.div(12, $shrine-font-size)rem,
     'weight': 400
   ),
   'overline':(
     'font-family': $body-font-family,
     'letter-spacing': initial,
-    'size': #{14 / $shrine-font-size}rem,
+    'size': math.div(14, $shrine-font-size)rem,
     'weight': 400
   )
 );


### PR DESCRIPTION
Updated syntax for SASS math:

```scss
@use 'sass:math';

// old
.some-class {
  size: #{14 / $preset-font-size}rem
}

// new 
.some-class {
  size: math.div(14, $preset-font-size)rem
}
```