### PR TITLE
fix(preview): install correct vite version.

### DIFF
--- a/packages/vue-cli-plugin-vuetify/generator/tools/vite.js
+++ b/packages/vue-cli-plugin-vuetify/generator/tools/vite.js
@@ -1,8 +1,8 @@
 function addDependencies(api) {
   api.extendPackage({
     devDependencies: {
-        '@vitejs/plugin-vue': '^1.1.5',
-        'vite': '~2.0.5',
+        '@vitejs/plugin-vue': '^1.2.4',
+        'vite': '^2.0.0',
       },
     scripts: {
       'serve': 'vite preview',


### PR DESCRIPTION
Update the installed version for `vite` and `@vitejs/plugin-vue` when using the Vuetify 3 Preview preset.