### PR TITLE
chore(vuetify-cli): Install latest beta version for vue cli plugins.

### DIFF
--- a/packages/vue-cli-plugin-vuetify/generator/tools/alaCarte.js
+++ b/packages/vue-cli-plugin-vuetify/generator/tools/alaCarte.js
@@ -7,6 +7,7 @@ function addDependencies (api, useV3) {
     },
   }
 
+  // @TODO temporary fix for Vuetify 3 only
   if (useV3) {
     deps.devDependencies['@vue/cli-service'] = '5.0.0-beta.7'
     deps.devDependencies['@vue/cli-plugin-babel'] = '5.0.0-beta.7'

--- a/packages/vue-cli-plugin-vuetify/generator/tools/alaCarte.js
+++ b/packages/vue-cli-plugin-vuetify/generator/tools/alaCarte.js
@@ -7,7 +7,10 @@ function addDependencies (api, useV3) {
     },
   }
 
-  if (useV3) deps.devDependencies['@vue/cli-service'] = '~5.0.0-beta.3'
+  if (useV3) {
+    deps.devDependencies['@vue/cli-service'] = '5.0.0-beta.7'
+    deps.devDependencies['@vue/cli-plugin-babel'] = '5.0.0-beta.7'
+  }
 
   api.extendPackage(deps)
 }


### PR DESCRIPTION
Force install the following when generating a Vue 3 and Vuetify 3 project:
  - `@vue/cli-service`: `5.0.0-beta.7`
  - `@vue/cli-plugin-babel`: `5.0.0-beta.7`