### PR TITLE
fix(plugin-vuetify): declare vue as a peer dependency

### DIFF
--- a/packages/vue-cli-plugin-vuetify/package.json
+++ b/packages/vue-cli-plugin-vuetify/package.json
@@ -38,7 +38,8 @@
     "vuetify-loader": "^1.4.3"
   },
   "peerDependencies": {
-    "webpack": "^4.0.0 || ^5.0.0"
+    "webpack": "^4.0.0 || ^5.0.0",
+    "vue": "*"
   },
   "peerDependenciesMeta": {
     "sass-loader": {


### PR DESCRIPTION
**What's the problem this PR addresses?**

`vue-cli-plugin-vuetify` attempts to require `vue` but doesn't declare it as a dependency.
https://github.com/vuetifyjs/vue-cli-plugins/blob/4a09f6e51a295333b3425f70a591ab819de4aaaf/packages/vue-cli-plugin-vuetify/index.js#L15

**How did you fix it?**

Added `vue` as a peer dependency.