### PR TITLE
refactor(vite): handle config for create-vue projects 

### DIFF
--- a/packages/vue-cli-plugin-vuetify/generator/index.js
+++ b/packages/vue-cli-plugin-vuetify/generator/index.js
@@ -28,10 +28,9 @@ module.exports = (api, opts) => {
   else if (opts.usePolyfill) polyfill.addDependencies(api)
 
   // Vite
-  if (opts.useVite) {
+  if (opts.useVite) { // @TODO Replace vite config if it doesn't already exist, otherwise inject the vuetify plugin
     vite.addDependencies(api)
     vite.renderFiles(api, opts)
-    vite.updateViteConfig(api, opts)
   }
 
   if (opts.installFonts) fonts.addDependencies(api, opts.iconFont)

--- a/packages/vue-cli-plugin-vuetify/generator/index.js
+++ b/packages/vue-cli-plugin-vuetify/generator/index.js
@@ -28,7 +28,7 @@ module.exports = (api, opts) => {
   else if (opts.usePolyfill) polyfill.addDependencies(api)
 
   // Vite
-  if (opts.useVite) { // @TODO Replace vite config if it doesn't already exist, otherwise inject the vuetify plugin
+  if (opts.useVite) {
     vite.addDependencies(api)
     vite.renderFiles(api, opts)
   }

--- a/packages/vue-cli-plugin-vuetify/generator/index.js
+++ b/packages/vue-cli-plugin-vuetify/generator/index.js
@@ -24,13 +24,14 @@ module.exports = (api, opts) => {
 
   // Add dependencies
   vuetify.addDependencies(api, opts)
-  if (opts.useAlaCarte) alaCarte.addDependencies(api, opts.useV3)
+  if (opts.useAlaCarte && !opts.useVite) alaCarte.addDependencies(api, opts.useV3)
   else if (opts.usePolyfill) polyfill.addDependencies(api)
 
   // Vite
   if (opts.useVite) {
     vite.addDependencies(api)
     vite.renderFiles(api, opts)
+    vite.updateViteConfig(api, opts)
   }
 
   if (opts.installFonts) fonts.addDependencies(api, opts.iconFont)
@@ -51,14 +52,18 @@ module.exports = (api, opts) => {
     if (!opts.installFonts) fonts.addLinks(api, opts.iconFont)
     vuetify.setHtmlLang(api, opts.locale)
 
-    if (fileExists(api, 'src/public/index.html')) {
-      fs.unlinkSync(api.resolve('src/public/index.html'))
+    if (fileExists(api, './src/public/index.html')) {
+      fs.unlinkSync(api.resolve('./src/public/index.html'))
     }
 
     const configFile = api.resolve('./vue.config.js')
 
     if (fileExists(api, configFile)) {
-      vuetify.addVuetifyLoaderDocsLink(configFile)
+      if (opts.useVite) {
+        fs.unlinkSync(configFile)
+      } else {
+        vuetify.addVuetifyLoaderDocsLink(configFile)
+      }
     }
 
     api.exitLog('Discord community: https://community.vuetifyjs.com')

--- a/packages/vue-cli-plugin-vuetify/generator/templates/v3/vite/vite.config.ts
+++ b/packages/vue-cli-plugin-vuetify/generator/templates/v3/vite/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
-import vuetify from '@vuetify/vite-plugin'
+import vuetify from 'vite-plugin-vuetify'
 
 const path = require('path')
 

--- a/packages/vue-cli-plugin-vuetify/generator/tools/vite.js
+++ b/packages/vue-cli-plugin-vuetify/generator/tools/vite.js
@@ -26,10 +26,29 @@ function renderFiles (api, opts) {
     './src/styles/_variables.scss': '../templates/v3/vite/styles/_variables.scss',
   }
 
-  if (!fileExists(api, viteConfigPath)) files[viteConfigFile] = `../templates/v3/vite/vite.config.${ext}`
+  if (!fileExists(api, viteConfigPath)) {
+    files[viteConfigFile] = `../templates/v3/vite/vite.config.${ext}`
+    updateJsConfigTarget(api)
+  }
   else updateViteConfig(api, viteConfigPath)
 
   api.render(files, opts)
+}
+
+function updateJsConfigTarget(api) {
+  const jsConfigPath = api.resolve('./jsconfig.json')
+
+  if (fileExists(api, jsConfigPath)) {
+    updateFile(api, jsConfigPath, (lines) => {
+      const targetIndex = lines.findIndex(line => line.match(/"target":/))
+
+      if (targetIndex !== -1) {
+        lines[targetIndex] = lines[targetIndex].replace('es5', 'esnext')
+      }
+
+      return lines
+    })
+  }
 }
 
 function updateViteConfig (api, viteConfigPath) {

--- a/packages/vue-cli-plugin-vuetify/generator/tools/vite.js
+++ b/packages/vue-cli-plugin-vuetify/generator/tools/vite.js
@@ -1,3 +1,5 @@
+const helpers = require('./helpers')
+
 function addDependencies (api) {
   api.extendPackage({
     devDependencies: {
@@ -17,14 +19,50 @@ function renderFiles (api, opts) {
   const ext = opts.hasTS ? 'ts' : 'js'
   const files = {
     './index.html': '../templates/v3/vite/index.vite.html',
-    [`./vite.config.${ext}`]: `../templates/v3/vite/vite.config.${ext}`,
+    // @TODO Remove
+    // [`./vite.config.${ext}`]: `../templates/v3/vite/vite.config.${ext}`,
     './src/styles/_variables.scss': '../templates/v3/vite/styles/_variables.scss',
   }
 
   api.render(files, opts)
 }
 
+function updateViteConfig (api, opts) {
+  const ext = opts.hasTs ? 'ts' : 'js'
+  const viteConfigPath = api.resolve(`./vite.config.${ext}`)
+  
+  helpers.updateFile(api, viteConfigPath, (lines) => {
+    const pluginsIndex = lines.findIndex(line => line.match(/plugins:/))
+    const importsIndex = lines.lastIndexOf("\nimport ")
+
+    const vuetifyPluginImport = `import vuetify from 'vite-plugin-vuetify\t'`
+    const vuetifyPlugin = '\n\t\tvuetify({ autoImport: true }),\n\t'
+
+    if (pluginsIndex !== -1) {
+      const matchedPlugins = lines[pluginsIndex].match(/(?<=\[).+?(?=\])/)
+
+      if (matchedPlugins !== null) {
+        const currentPluginsArr = matchedPlugins[0].split(',')
+        const allPlugins = ''.concat(
+          currentPluginsArr
+            .map(plugin => `\n\t\t${plugin.trim()}`)
+            .concat(vuetifyPlugin)
+          )
+
+        lines[pluginsIndex] = lines[pluginsIndex].replace(/(?<=\[).+?(?=\])/, allPlugins)
+
+        return lines
+      } else {
+        lines[pluginsIndex] = lines[pluginsIndex].replace(/\[.*\]/, vuetifyPlugin)
+
+        return lines
+      }
+    }
+  })
+}
+
 module.exports = {
   addDependencies,
   renderFiles,
+  updateViteConfig,
 }

--- a/packages/vue-cli-plugin-vuetify/generator/tools/vite.js
+++ b/packages/vue-cli-plugin-vuetify/generator/tools/vite.js
@@ -18,13 +18,15 @@ function addDependencies (api) {
 
 function renderFiles (api, opts) {
   const ext = opts.hasTS ? 'ts' : 'js'
-  const viteConfigPath = api.resolve(`./vite.config.${ext}`)
+  const viteConfigFile = `./vite.config.${ext}`
+  const viteConfigPath = api.resolve(viteConfigFile)
+
   const files = {
     './index.html': '../templates/v3/vite/index.vite.html',
     './src/styles/_variables.scss': '../templates/v3/vite/styles/_variables.scss',
   }
 
-  if (!fileExists(api, viteConfigPath)) files[viteConfigPath] = `../templates/v3/vite/vite.config.${ext}`
+  if (!fileExists(api, viteConfigPath)) files[viteConfigFile] = `../templates/v3/vite/vite.config.${ext}`
   else updateViteConfig(api, viteConfigPath)
 
   api.render(files, opts)
@@ -36,7 +38,7 @@ function updateViteConfig (api, viteConfigPath) {
     const exportIndex = lines.findIndex(line => line.includes('export default'))
 
     const vuetifyPluginImport = `\n// https://github.com/vuetifyjs/vuetify-loader/tree/next/packages/vite-plugin\nimport vuetify from 'vite-plugin-vuetify'\n`
-    const vuetifyPlugin = '\n\t\tvuetify({ autoImport: true }),\n\t'
+    const vuetifyPlugin = '\n\t\tvuetify({ autoImport: true }),\n'
 
     if (pluginsIndex !== -1) {
       lines[exportIndex - 2] = vuetifyPluginImport


### PR DESCRIPTION
### Fixes:
  - Injects `vite-plugin-vuetify` plugin into the Vite config when a project is generated with the `vue-create` package
  - Add correct `vite-plugin-vuetify` Vite config import when generating a TS project with `vue-cli-plugins` 
  - Updates ESBuild target for JS Vite projects generated with a `jsconfig.json` file: Replaces `'es5'` with `'esnext'`
  - Stop installing `webpack-plugin-vuetify` when the project is a Vite project