### PR TITLE
enabling components to be rendered when starting Template the first time

### DIFF
--- a/packages/vue-cli-plugin-vuetify/generator/templates/v3/src/plugins/vuetify.js
+++ b/packages/vue-cli-plugin-vuetify/generator/templates/v3/src/plugins/vuetify.js
@@ -1,10 +1,16 @@
 // Styles
 import '@mdi/font/css/materialdesignicons.css'
 import 'vuetify/styles'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
 
 // Vuetify
 import { createVuetify } from 'vuetify'
 
 export default createVuetify(
+  {
+    components,
+    directives,
+  }
   // https://vuetifyjs.com/en/introduction/why-vuetify/#feature-guides
 )


### PR DESCRIPTION
I noticed that when I first start the template for Vite, no components are displayed. These lines have fixed the problem. Hope this helps.